### PR TITLE
Films Endpoint Fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ app.get("/films", (req: Request, res: Response) => {
   }
 
   const response = JSON.stringify({ data: films });
-  res.send(response).setHeader("x-custom-header", neededHeader);
+  res.setHeader("x-custom-header", neededHeader).send(response);
 });
 
 app.get("/token", (req: Request, res: Response) => {


### PR DESCRIPTION
`/films` endpoint was setting a header after sending the response, causing a non-breaking exception.
![image](https://github.com/user-attachments/assets/c703f3f9-b146-48c3-ab01-cebf332b8609)

This has been fixed by swapping the order it sends the response and sets the header in.